### PR TITLE
FileLogger - get all logs unarchived

### DIFF
--- a/Sources/Logger/Loggers/FileLogger/FileLogger.swift
+++ b/Sources/Logger/Loggers/FileLogger/FileLogger.swift
@@ -30,6 +30,10 @@ public class FileLogger: Logging {
 //    public var archivedLogFiles: Archive? {
 //        fileLoggerManager.archivedLogFiles
 //    }
+    
+    public var logFilesUrl: [URL]? {
+        fileLoggerManager.gettingAllLogFiles()
+    }
 
     public var levels: [Level] = [.info]
 


### PR DESCRIPTION
Get all logs as unarchived ones, so the archivation may be performed later (and elsewhere)