### PR TITLE
Namespacing support for multiple FileLogger instances

### DIFF
--- a/Sources/Logger/Loggers/FileLogger/FileManager+.swift
+++ b/Sources/Logger/Loggers/FileLogger/FileManager+.swift
@@ -29,7 +29,7 @@ extension FileManager {
             for: .documentDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
-            create: true
+            create: false
         ))
         .appendingPathComponent(name)
     }

--- a/Tests/LoggerTests/Loggers/FileLogger+helpers.swift
+++ b/Tests/LoggerTests/Loggers/FileLogger+helpers.swift
@@ -1,0 +1,27 @@
+//
+//  FileManager+helpers.swift
+//  
+//
+//  Created by Martin Troup on 15.07.2022.
+//
+
+import Foundation
+
+private extension URL {
+    var isDirectory: Bool {
+       (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+    }
+}
+
+extension FileManager {
+    func directoryExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileExists(atPath: url.path, isDirectory: &isDirectory) && url.isDirectory
+    }
+
+    func numberOfFiles(inDirectory url: URL) throws -> Int {
+        try contentsOfDirectory(atPath: url.path).count
+    }
+}
+
+

--- a/Tests/LoggerTests/Loggers/FileLogger+sharedTests.swift
+++ b/Tests/LoggerTests/Loggers/FileLogger+sharedTests.swift
@@ -1,0 +1,88 @@
+//
+//  FileLogger+sharedTests.swift
+//  
+//
+//  Created by Martin Troup on 14.07.2022.
+//
+
+@testable import Logger
+import XCTest
+
+class FileLogger_sharedTests: XCTestCase {
+    private let appGroupID = "test-app-group-id"
+    private let namespace = "test-namespace"
+    private var fileManager: FileManager!
+    private var userDefaults: UserDefaults!
+    private var logDirURL: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        self.fileManager = FileManager.default
+        self.userDefaults = UserDefaults(suiteName: appGroupID)!
+
+        self.logDirURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupID)!
+            .appendingPathComponent(namespace)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: appGroupID)
+        
+        if fileManager.directoryExists(at: logDirURL) {
+            try! fileManager.removeItem(atPath: logDirURL.path)
+        }
+
+        super.tearDown()
+    }
+    
+    func test_inicialization_of_FileLogger_with_shared_configuration() throws {
+        let appName = "test-app-name"
+
+        let fileLogger = try FileLogger(
+            sharingConfiguration: .shared(
+                appGroupID: appGroupID,
+                maxNumberOfFiles: 3,
+                appName: appName
+            ),
+            namespace: namespace,
+            fileHeaderContent: "",
+            lineSeparator: "\n",
+            logEntryEncoder: LogEntryEncoder(),
+            logEntryDecoder: LogEntryDecoder(),
+            loggerForInternalErrors: { _ in }
+        )
+
+        XCTAssertTrue(fileManager.directoryExists(at: logDirURL))
+        XCTAssertEqual(try fileManager.numberOfFiles(inDirectory: logDirURL), 0)
+
+        XCTAssertEqual(
+            fileLogger.currentLogFileUrl,
+            logDirURL.appendingPathComponent("\(appName)-0").appendingPathExtension("log")
+        )
+
+        let currentLogFileNumber = userDefaults.object(
+            forKey: "\(namespace)-\(Constants.UserDefaultsKeys.currentLogFileNumber)"
+        ) as? Int
+        XCTAssertEqual(currentLogFileNumber, 0)
+
+        let dateOfLastLog = userDefaults.object(forKey: "\(namespace)-\(Constants.UserDefaultsKeys.dateOfLastLog)") as? Date
+        XCTAssertNotNil(dateOfLastLog)
+
+        let numberOfLogFiles = userDefaults.object(forKey: "\(namespace)-\(Constants.UserDefaultsKeys.numberOfLogFiles)") as? Int
+        XCTAssertEqual(numberOfLogFiles, 3)
+    }
+
+}
+
+// MARK: - FileManager + helper functions
+
+private extension FileManager {
+    func directoryExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileExists(atPath: url.path, isDirectory: &isDirectory)
+    }
+
+    func numberOfFiles(inDirectory url: URL) throws -> Int {
+        try contentsOfDirectory(atPath: url.path).count
+    }
+}

--- a/Tests/LoggerTests/Loggers/FileLogger+sharedTests.swift
+++ b/Tests/LoggerTests/Loggers/FileLogger+sharedTests.swift
@@ -71,18 +71,4 @@ class FileLogger_sharedTests: XCTestCase {
         let numberOfLogFiles = userDefaults.object(forKey: "\(namespace)-\(Constants.UserDefaultsKeys.numberOfLogFiles)") as? Int
         XCTAssertEqual(numberOfLogFiles, 3)
     }
-
-}
-
-// MARK: - FileManager + helper functions
-
-private extension FileManager {
-    func directoryExists(at url: URL) -> Bool {
-        var isDirectory: ObjCBool = false
-        return fileExists(atPath: url.path, isDirectory: &isDirectory)
-    }
-
-    func numberOfFiles(inDirectory url: URL) throws -> Int {
-        try contentsOfDirectory(atPath: url.path).count
-    }
 }

--- a/Tests/LoggerTests/Loggers/FileLoggerTests.swift
+++ b/Tests/LoggerTests/Loggers/FileLoggerTests.swift
@@ -453,17 +453,6 @@ class FileLoggerTests: XCTestCase {
 
 // MARK: - FileManager + helper functions
 
-private extension FileManager {
-    func directoryExists(at url: URL) -> Bool {
-        var isDirectory: ObjCBool = false
-        return fileExists(atPath: url.path, isDirectory: &isDirectory)
-    }
-
-    func numberOfFiles(inDirectory url: URL) throws -> Int {
-        try contentsOfDirectory(atPath: url.path).count
-    }
-}
-
 private extension FileLoggerTests {
     struct MockedCodable: Codable {
         var int: Int


### PR DESCRIPTION
- namespacing to support multiple instances of `FileLogger`
- improved ergonomics of `FileLogger` init