### PR TITLE
FIX: Filelogger logging after erasing all files

### DIFF
--- a/Sources/Logger/Loggers/FileLogger/FileLogger.swift
+++ b/Sources/Logger/Loggers/FileLogger/FileLogger.swift
@@ -226,6 +226,8 @@ public class FileLogger: Logging {
 
     public func deleteAllLogFiles() throws {
         try fileManager.deleteAllFiles(at: logDirURL, withPathExtension: logFilePathExtension)
+        currentWritableFileHandle = nil
+        currentLogFileNumber = 0
     }
 
     public var logFiles: [URL] {

--- a/Tests/LoggerTests/Loggers/FileLoggerTests.swift
+++ b/Tests/LoggerTests/Loggers/FileLoggerTests.swift
@@ -450,7 +450,7 @@ class FileLoggerTests: XCTestCase {
         XCTAssertEqual(fileLogs[4].message.description, encodedCodableString)
     }
     
-    func test_delete_log_files() throws {
+    func test_deleting_log_files_resets_the_logger_configuration() throws {
         let fileLogger = try FileLogger(
             appName: nil,
             fileManager: fileManager,


### PR DESCRIPTION
Fixes Filelogger logging after erasing all files.

Added following logic to deleteAllLogFiles method:
- Clears invalid file handle
- Resets current log number to zero