### PR TITLE
Relog meta information for new log files

### DIFF
--- a/Sources/Logger/Loggers/FileLogger/FileLogger.swift
+++ b/Sources/Logger/Loggers/FileLogger/FileLogger.swift
@@ -291,19 +291,14 @@ public class FileLogger: Logging {
             currentLogFileNumber = 0
         }
 
-        let dateString = DateFormatter.dateFormatter.string(from:)
-
         let currentDate = Date()
 
-        let isSameDay = dateString(currentDate) == dateString(dateOfLastLog)
-
-        if isSameDay, currentWritableFileHandle == nil {
-            currentWritableFileHandle = try fileHandle(fileManager, currentLogFileUrl)
-
+        if Calendar.current.isDate(currentDate, inSameDayAs: dateOfLastLog) {
+            if currentWritableFileHandle == nil {
+                currentWritableFileHandle = try fileHandle(fileManager, currentLogFileUrl)
+            }
             return
         }
-
-        if isSameDay { return }
 
         currentLogFileNumber = (currentLogFileNumber + 1) % numberOfLogFiles
         dateOfLastLog = currentDate


### PR DESCRIPTION
Meta informations are currently logged only once, when the logger is initialized - which we don't like with combination with FileLogger, where the log files can be missing this info. So I have updated the meta information logging so it will be logger before the first log after initialization, after deleting log files or after new day.