### PR TITLE
FileLogger: use throwing FileHandle API so a failed write cannot cras…

### DIFF
--- a/Sources/Logger/Loggers/FileLogger/FileLogger.swift
+++ b/Sources/Logger/Loggers/FileLogger/FileLogger.swift
@@ -68,10 +68,10 @@ public class FileLogger: Logging {
         }
     }
     
-    private var currentWritableFileHandle: FileHandle? {
+    var currentWritableFileHandle: FileHandle? {
         willSet {
             if currentWritableFileHandle != newValue {
-                currentWritableFileHandle?.closeFile()
+                try? currentWritableFileHandle?.close()
             }
         }
     }
@@ -264,8 +264,8 @@ public class FileLogger: Logging {
                     throw FileLoggerError.stringToDataConversionFailure
                 }
 
-                fileHandle.seekToEndOfFile()
-                fileHandle.write(data)
+                try fileHandle.seekToEnd()
+                try fileHandle.write(contentsOf: data)
             } catch let error {
                 self.externalLogger("Failed to write to a log file with error: \(error)!")
             }

--- a/Tests/LoggerTests/Loggers/FileLoggerTests.swift
+++ b/Tests/LoggerTests/Loggers/FileLoggerTests.swift
@@ -196,6 +196,41 @@ class FileLoggerTests: XCTestCase {
         }
     }
 
+    func test_failed_write_is_reported_instead_of_crashing() throws {
+        var internalErrors: [String] = []
+
+        let fileLogger = try FileLogger(
+            appName: nil,
+            fileManager: fileManager,
+            userDefaults: userDefaults,
+            logDirURL: logDirURL,
+            namespace: nil,
+            numberOfLogFiles: 3,
+            dateFormatter: DateFormatter.dateFormatter,
+            fileHeaderContent: "",
+            lineSeparator: "\n",
+            logEntryEncoder: LogEntryEncoder(),
+            logEntryDecoder: LogEntryDecoder(),
+            externalLogger: { internalErrors.append($0) },
+            fileAccessQueue: .syncMock
+        )
+
+        fileLogger.log(.mock("First message"))
+
+        // Simulate an I/O failure (e.g. "No space left on device") with a handle that cannot be written to.
+        // The legacy `seekToEndOfFile()` / `write(_:)` API raised an uncatchable NSException here and crashed the app.
+        fileLogger.currentWritableFileHandle = try FileHandle(forReadingFrom: fileLogger.currentLogFileUrl)
+
+        fileLogger.log(.mock("Second message"))
+
+        XCTAssertEqual(internalErrors.count, 1)
+        XCTAssertTrue(internalErrors.first?.hasPrefix("Failed to write to a log file") == true, internalErrors.description)
+
+        let content = try String(contentsOf: fileLogger.currentLogFileUrl, encoding: .utf8)
+        XCTAssertTrue(content.contains("First message"), content)
+        XCTAssertFalse(content.contains("Second message"), content)
+    }
+
     func test_file_rotation() throws {
         let fileLogger = try FileLogger(
             appName: nil,


### PR DESCRIPTION
Problem
FileLogger.log(_:) appends through the legacy FileHandle.seekToEndOfFile() / write(_:) API. When the underlying write fails (typically ENOSPC, "No space left on device", when the device storage is full) Foundation raises an Objective-C NSFileHandleOperationException. That exception cannot be caught from Swift, so the whole app crashes on the logger's background queue.

Fix
Use the throwing FileHandle API (seekToEnd(), write(contentsOf:), close()), available since iOS 13.4 / macOS 10.15.4, well below the package's platform floor. A failed write now throws a Swift error that lands in the existing catch and is reported through loggerForInternalErrors; the entry is dropped and the app keeps running.
currentWritableFileHandle is now internal (was private) so the test can inject a failing handle.
Test
test_failed_write_is_reported_instead_of_crashing swaps the writable handle for a read-only one and logs again. With the old API the test process dies with NSFileHandleOperationException: Bad file descriptor; with this change the error is reported and the previously written content stays intact.